### PR TITLE
Add a command line option for HTTP proxy support

### DIFF
--- a/lib/twurl/cli.rb
+++ b/lib/twurl/cli.rb
@@ -72,6 +72,7 @@ module Twurl
             request_method
             help
             version
+            proxy
           end
         end
 
@@ -237,6 +238,12 @@ module Twurl
           exit
         end
       end
+
+      def proxy
+        on('-P', '--proxy [proxy]', 'Specify HTTP proxy to forward requests to (default: No proxy)') do |proxy|
+          options.proxy = proxy
+        end
+      end
     end
   end
 
@@ -274,6 +281,10 @@ module Twurl
 
     def host
       super || DEFAULT_HOST
+    end
+
+    def proxy
+      super || nil
     end
   end
 end

--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -163,7 +163,8 @@ module Twurl
         OAuth::Consumer.new(
           consumer_key,
           consumer_secret,
-          :site => Twurl.options.base_url
+          :site => Twurl.options.base_url,
+          :proxy => Twurl.options.proxy
         )
     end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -150,4 +150,21 @@ class Twurl::CLI::OptionParsingTest < MiniTest::Unit::TestCase
     end
   end
   include HostOptionTests
+
+  module ProxyOptionTests
+    def test_not_specifying_proxy_sets_it_to_nil
+      options = Twurl::CLI.parse_options([])
+      assert_equal nil, options.proxy
+    end
+
+    def test_setting_proxy_updates_to_requested_value
+      custom_proxy = 'localhost:80'
+
+      [['-P', custom_proxy], ['--proxy', custom_proxy]].each do |option_combination|
+        options = Twurl::CLI.parse_options(option_combination)
+        assert_equal custom_proxy, options.proxy
+      end
+    end
+  end
+  include ProxyOptionTests
 end


### PR DESCRIPTION
I've been using twurl for some API debugging work and wanted to inspect requests in Charles proxy.  I saw the pull request which implemented this using an environment variable and decided to add a command line option and tests like you requested in https://github.com/marcel/twurl/pull/7

I've written almost no Ruby code before so any criticism or suggestions would be most welcome.  I've also added some superficial unit tests, but if you have any others you'd recommend, I'm happy to try and implement them.
