### PR TITLE
Enable use of the streaming API

### DIFF
--- a/lib/twurl/cli.rb
+++ b/lib/twurl/cli.rb
@@ -92,10 +92,12 @@ module Twurl
 
       def print(*args, &block)
         output.print(*args, &block)
+        output.flush if output.respond_to?(:flush)
       end
 
       def puts(*args, &block)
         output.puts(*args, &block)
+        output.flush if output.respond_to?(:flush)
       end
 
       def prompt_for(label)

--- a/lib/twurl/request_controller.rb
+++ b/lib/twurl/request_controller.rb
@@ -10,8 +10,9 @@ module Twurl
     end
 
     def perform_request
-      response = client.perform_request_from_options(options)
-      CLI.print response.body
+      client.perform_request_from_options(options) { |response|
+        response.read_body { |chunk| CLI.print chunk }
+      }
     rescue URI::InvalidURIError
       CLI.puts NO_URI_MESSAGE
     end

--- a/test/oauth_client_test.rb
+++ b/test/oauth_client_test.rb
@@ -135,7 +135,9 @@ end
 class Twurl::OAuthClient::PerformingRequestsFromOptionsTest < Twurl::OAuthClient::AbstractOAuthClientTest
   def test_request_is_made_using_request_method_and_path_and_data_in_options
     client = Twurl::OAuthClient.test_exemplar
-    mock(client).get(options.path, options.data)
+    mock(client.consumer.http).request(satisfy { |req|
+                                         req.is_a?(Net::HTTP::Get) && (req.path == options.path)
+                                       })
 
     client.perform_request_from_options(options)
   end

--- a/test/request_controller_test.rb
+++ b/test/request_controller_test.rb
@@ -41,8 +41,8 @@ class Twurl::RequestController::RequestTest < Twurl::RequestController::Abstract
   def test_request_response_is_written_to_output
     expected_body = 'this is a fake response body'
     response      = Object.new
-    mock(response).body.times(1) { expected_body }
-    mock(client).perform_request_from_options(options).times(1) { response }
+    mock(response).read_body { |block| block.call expected_body }
+    mock(client).perform_request_from_options(options).times(1) { |options, block| block.call(response) }
 
     controller.perform_request
 


### PR DESCRIPTION
The streaming API didn't work through twurl, since the way that the HTTP API was used, it was reading the whole response before doing any output. This change makes it possible to use the streaming API by reading the response in chunks and writing them out as they come.
