### PR TITLE
3 Twurl::CLI modifications for improved usability

### DIFF
--- a/lib/twurl/cli.rb
+++ b/lib/twurl/cli.rb
@@ -6,12 +6,18 @@ module Twurl
     PROTOCOL_PATTERN       = /^\w+:\/\//
     README                 = File.dirname(__FILE__) + '/../../README'
     @output              ||= STDOUT
+    class NoPathFound < Exception
+    end
 
     class << self
       attr_accessor :output
 
       def run(args)
-        options = parse_options(args)
+        begin
+          options = parse_options(args)
+        rescue NoPathFound => e
+          exit
+        end
         dispatch(options)
       end
 
@@ -85,7 +91,7 @@ Supported Commands: #{SUPPORTED_COMMANDS.sort.join(', ')}
 
         if Twurl.options.command == DEFAULT_COMMAND and Twurl.options.path.nil?
           CLI.puts option_parser
-          exit
+          raise NoPathFound, "No path found"
         end
 
         Twurl.options.subcommands = arguments

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,9 +1,11 @@
 require File.dirname(__FILE__) + '/test_helper'
 
 class Twurl::CLI::OptionParsingTest < Minitest::Test
+  TEST_PATH = '/1.1/url/does/not/matter.json'
+
   module CommandParsingTests
     def test_no_command_specified_falls_to_default_command
-      options = Twurl::CLI.parse_options(['/1.1/url/does/not/matter.json'])
+      options = Twurl::CLI.parse_options([TEST_PATH])
       assert_equal Twurl::CLI::DEFAULT_COMMAND, options.command
     end
 
@@ -15,24 +17,38 @@ class Twurl::CLI::OptionParsingTest < Minitest::Test
 
     def test_unsupported_command_specified_sets_default_command
       unsupported_command = 'unsupported'
-      options = Twurl::CLI.parse_options([unsupported_command])
+      options = Twurl::CLI.parse_options([TEST_PATH, unsupported_command])
       assert_equal Twurl::CLI::DEFAULT_COMMAND, options.command
     end
   end
   include CommandParsingTests
 
+  module PathParsingTests
+    def test_missing_path_throws_no_path_found
+      stub(Twurl::CLI).puts
+      assert_raises Twurl::CLI::NoPathFound do
+        Twurl::CLI.parse_options([])
+      end
+    end
+
+    def test_uri_params_are_encoded
+      options = Twurl::CLI.parse_options(["/1.1/url?baz=bamf:rofl"])
+      assert_equal options.path, "/1.1/url?baz=bamf%3Arofl"
+    end
+  end
+  include PathParsingTests
+
   module RequestMethodParsingTests
     def test_request_method_is_default_if_unspecified
-      options = Twurl::CLI.parse_options(['/1.1/url/does/not/matter.json'])
+      options = Twurl::CLI.parse_options([TEST_PATH])
       assert_equal Twurl::Options::DEFAULT_REQUEST_METHOD, options.request_method
     end
 
     def test_specifying_a_request_method_extracts_and_normalizes_request_method
       variations = [%w[-X put], %w[-X PUT], %w[--request-method PUT], %w[--request-method put]]
       variations.each do |option_variation|
-        path = '/1.1/url/does/not/matter.json'
-        order_variant_1 = [option_variation, path].flatten
-        order_variant_2 = [path, option_variation].flatten
+        order_variant_1 = [option_variation, TEST_PATH].flatten
+        order_variant_2 = [TEST_PATH, option_variation].flatten
         [order_variant_1, order_variant_2].each do |args|
           options = Twurl::CLI.parse_options(args)
           assert_equal 'put', options.request_method
@@ -41,7 +57,7 @@ class Twurl::CLI::OptionParsingTest < Minitest::Test
     end
 
     def test_specifying_unsupported_request_method_returns_an_error
-      Twurl::CLI.parse_options(['-X', 'UNSUPPORTED'])
+      Twurl::CLI.parse_options([TEST_PATH, '-X', 'UNSUPPORTED'])
     end
   end
   include RequestMethodParsingTests
@@ -50,13 +66,13 @@ class Twurl::CLI::OptionParsingTest < Minitest::Test
     def test_extracting_the_consumer_key
       mock(Twurl::CLI).prompt_for('Consumer key').never
 
-      options = Twurl::CLI.parse_options(['-c', 'the-key'])
+      options = Twurl::CLI.parse_options([TEST_PATH, '-c', 'the-key'])
       assert_equal 'the-key', options.consumer_key
     end
 
     def test_consumer_key_option_with_no_value_prompts_user_for_value
       mock(Twurl::CLI).prompt_for('Consumer key').times(1) { 'inputted-key'}
-      options = Twurl::CLI.parse_options(['-c'])
+      options = Twurl::CLI.parse_options([TEST_PATH, '-c'])
       assert_equal 'inputted-key', options.consumer_key
     end
   end
@@ -64,39 +80,39 @@ class Twurl::CLI::OptionParsingTest < Minitest::Test
 
   module DataParsingTests
     def test_extracting_a_single_key_value_pair
-      options = Twurl::CLI.parse_options(['-d', 'key=value'])
+      options = Twurl::CLI.parse_options([TEST_PATH, '-d', 'key=value'])
       assert_equal({'key' => 'value'}, options.data)
 
-      options = Twurl::CLI.parse_options(['--data', 'key=value'])
+      options = Twurl::CLI.parse_options([TEST_PATH, '--data', 'key=value'])
       assert_equal({'key' => 'value'}, options.data)
     end
 
     def test_passing_data_and_no_explicit_request_method_defaults_request_method_to_post
-      options = Twurl::CLI.parse_options(['-d', 'key=value'])
+      options = Twurl::CLI.parse_options([TEST_PATH, '-d', 'key=value'])
       assert_equal 'post', options.request_method
     end
 
     def test_passing_data_and_an_explicit_request_method_uses_the_specified_method
-      options = Twurl::CLI.parse_options(['-d', 'key=value', '-X', 'DELETE'])
+      options = Twurl::CLI.parse_options([TEST_PATH, '-d', 'key=value', '-X', 'DELETE'])
       assert_equal({'key' => 'value'}, options.data)
       assert_equal 'delete', options.request_method
     end
 
     def test_multiple_pairs_when_option_is_specified_multiple_times_on_command_line_collects_all
-      options = Twurl::CLI.parse_options(['-d', 'key=value', '-d', 'another=pair'])
+      options = Twurl::CLI.parse_options([TEST_PATH, '-d', 'key=value', '-d', 'another=pair'])
       assert_equal({'key' => 'value', 'another' => 'pair'}, options.data)
     end
 
     def test_multiple_pairs_separated_by_ampersand_are_all_captured
-      options = Twurl::CLI.parse_options(['-d', 'key=value&another=pair'])
+      options = Twurl::CLI.parse_options([TEST_PATH, '-d', 'key=value&another=pair'])
       assert_equal({'key' => 'value', 'another' => 'pair'}, options.data)
     end
 
     def test_extracting_an_empty_key_value_pair
-      options = Twurl::CLI.parse_options(['-d', 'key='])
+      options = Twurl::CLI.parse_options([TEST_PATH, '-d', 'key='])
       assert_equal({'key' => ''}, options.data)
 
-      options = Twurl::CLI.parse_options(['--data', 'key='])
+      options = Twurl::CLI.parse_options([TEST_PATH, '--data', 'key='])
       assert_equal({'key' => ''}, options.data)
     end
   end
@@ -104,15 +120,15 @@ class Twurl::CLI::OptionParsingTest < Minitest::Test
 
   module HeaderParsingTests
     def test_extracting_a_single_header
-      options = Twurl::CLI.parse_options(['-A', 'Key: Value'])
+      options = Twurl::CLI.parse_options([TEST_PATH, '-A', 'Key: Value'])
       assert_equal({'Key' => 'Value'}, options.headers)
 
-      options = Twurl::CLI.parse_options(['--header', 'Key: Value'])
+      options = Twurl::CLI.parse_options([TEST_PATH, '--header', 'Key: Value'])
       assert_equal({'Key' => 'Value'}, options.headers)
     end
 
     def test_multiple_headers_when_option_is_specified_multiple_times_on_command_line_collects_all
-      options = Twurl::CLI.parse_options(['-A', 'Key: Value', '-A', 'Another: Pair'])
+      options = Twurl::CLI.parse_options([TEST_PATH, '-A', 'Key: Value', '-A', 'Another: Pair'])
       assert_equal({'Key' => 'Value', 'Another' => 'Pair'}, options.headers)
     end
   end
@@ -120,13 +136,13 @@ class Twurl::CLI::OptionParsingTest < Minitest::Test
 
   module SSLDisablingTests
     def test_ssl_is_on_by_default
-      options = Twurl::CLI.parse_options([])
+      options = Twurl::CLI.parse_options([TEST_PATH])
       assert options.ssl?
     end
 
     def test_passing_no_ssl_option_disables_ssl
       ['-U', '--no-ssl'].each do |switch|
-        options = Twurl::CLI.parse_options([switch])
+        options = Twurl::CLI.parse_options([TEST_PATH, switch])
         assert !options.ssl?
       end
     end
@@ -135,7 +151,7 @@ class Twurl::CLI::OptionParsingTest < Minitest::Test
 
   module HostOptionTests
     def test_not_specifying_host_sets_it_to_the_default
-      options = Twurl::CLI.parse_options([])
+      options = Twurl::CLI.parse_options([TEST_PATH])
       assert_equal Twurl::Options::DEFAULT_HOST, options.host
     end
 
@@ -143,24 +159,30 @@ class Twurl::CLI::OptionParsingTest < Minitest::Test
       custom_host = 'localhost:3000'
       assert Twurl::Options::DEFAULT_HOST != custom_host
 
-      [['-H', custom_host], ['--host', custom_host]].each do |option_combination|
+      [[TEST_PATH, '-H', custom_host], [TEST_PATH, '--host', custom_host]].each do |option_combination|
         options = Twurl::CLI.parse_options(option_combination)
         assert_equal custom_host, options.host
       end
+    end
+
+    def test_protocol_is_stripped_from_host
+      custom_host = 'localhost:3000'
+      options = Twurl::CLI.parse_options([TEST_PATH, '-H', "https://"+custom_host])
+      assert_equal custom_host, options.host
     end
   end
   include HostOptionTests
 
   module ProxyOptionTests
     def test_not_specifying_proxy_sets_it_to_nil
-      options = Twurl::CLI.parse_options([])
+      options = Twurl::CLI.parse_options([TEST_PATH])
       assert_equal nil, options.proxy
     end
 
     def test_setting_proxy_updates_to_requested_value
       custom_proxy = 'localhost:80'
 
-      [['-P', custom_proxy], ['--proxy', custom_proxy]].each do |option_combination|
+      [[TEST_PATH, '-P', custom_proxy], [TEST_PATH, '--proxy', custom_proxy]].each do |option_combination|
         options = Twurl::CLI.parse_options(option_combination)
         assert_equal custom_proxy, options.proxy
       end


### PR DESCRIPTION
1. Unfriendly starting exception
   The  twurl command when invoked by itself throws an error

```
$ twurl
/Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/1.8/net/http.rb:1478:in `initialize': HTTP request path is empty (ArgumentError)
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/1.8/net/http.rb:1596:in `initialize'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/oauth_client.rb:77:in `new'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/oauth_client.rb:77:in `perform_request_from_options'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/request_controller.rb:13:in `perform_request'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/request_controller.rb:9:in `dispatch'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/abstract_command_controller.rb:7:in `dispatch'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/cli.rb:31:in `dispatch'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/cli.rb:14:in `run'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/twurl:4
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/bin/twurl:19:in `load'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/bin/twurl:19
```

This pull request shows the --help menu instead.
1. Unfriendly host with protocol exception
   When accidentally including the protocol as part of the host, one receives the following error:

```
$ twurl -H https://other-api.example.com /0/test
/Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/1.8/net/http.rb:560:in `initialize': getaddrinfo: nodename nor servname provided, or not known (SocketError)
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/1.8/net/http.rb:560:in `open'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/1.8/net/http.rb:560:in `connect'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/1.8/timeout.rb:67:in `timeout'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/1.8/timeout.rb:101:in `timeout'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/1.8/net/http.rb:560:in `connect'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/1.8/net/http.rb:553:in `do_start'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/1.8/net/http.rb:542:in `start'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/1.8/net/http.rb:1035:in `request'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/oauth_client.rb:80:in `perform_request_from_options'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/request_controller.rb:13:in `perform_request'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/request_controller.rb:9:in `dispatch'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/abstract_command_controller.rb:7:in `dispatch'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/cli.rb:31:in `dispatch'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/../lib/twurl/cli.rb:14:in `run'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/lib/ruby/gems/1.8/gems/twurl-0.8.1/bin/twurl:4
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/bin/twurl:19:in `load'
    from /Users/sarahbrown/.rbenv/versions/ree-1.8.7-2011.03/bin/twurl:19
```

It's hard to understand what is wrong with the host from this message. This is an easy mistake to make when the user is familiar with curl, where the protocol is required. This request removes any extra protocol from the host.
1. Encoding url parameters
   Parameters such as "?start_time=2013-01-06T07:59:00Z" should be encoded as "?start_time=2013-01-06T07%3A59%3A00Z"
