### PR TITLE
Add ability to set consumer names

### DIFF
--- a/README
+++ b/README
@@ -42,6 +42,13 @@ a variant of the above
 And, again assuming your username, password, key and secret is
 correct, will authorize you in one step.
 
+If you use many consumer applications then you can name them when
+authorizing to keep track of which is which.
+
+  % twurl authorize --consumer-key key       \
+                    --consumer-secret secret \
+                    --consumer-name name
+
 +-----------------+
 | Making Requests |
 +-----------------+

--- a/README
+++ b/README
@@ -29,7 +29,7 @@ and secret.
 
 This will return an URL that you should open up in your browser.
 Authenticate to Twitter, and then enter the returned PIN back into
-the terminal.  Assuming all that works well, you will beauthorized
+the terminal.  Assuming all that works well, you will be authorized
 to make requests with the API. Twurl will tell you as much.
 
 If your consumer application has xAuth enabled, then you can use

--- a/lib/twurl/account_information_controller.rb
+++ b/lib/twurl/account_information_controller.rb
@@ -10,8 +10,9 @@ module Twurl
         profiles = rcfile.profiles
         profiles.keys.sort.each do |account_name|
           CLI.puts account_name
-          profiles[account_name].each do |consumer_key, _|
+          profiles[account_name].each do |consumer_key, properties|
             account_summary = "  #{consumer_key}"
+            account_summary << " - #{properties['consumer_name']}" if properties['consumer_name']
             account_summary << " (default)" if rcfile.default_profile == [account_name, consumer_key]
             CLI.puts account_summary
           end

--- a/lib/twurl/cli.rb
+++ b/lib/twurl/cli.rb
@@ -67,6 +67,7 @@ Supported Commands: #{SUPPORTED_COMMANDS.sort.join(', ')}
             password
             consumer_key
             consumer_secret
+            consumer_name
             access_token
             token_secret
           end
@@ -189,6 +190,12 @@ Supported Commands: #{SUPPORTED_COMMANDS.sort.join(', ')}
       def consumer_secret
         on('-s', '--consumer-secret [secret]', "Your consumer secret (required)") do |secret|
           options.consumer_secret = secret ? secret : CLI.prompt_for('Consumer secret')
+        end
+      end
+
+      def consumer_name
+        on('-n', '--consumer-name [name]', "Name to identify consumer") do |name|
+          options.consumer_name = name
         end
       end
 

--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -49,7 +49,7 @@ module Twurl
       end
     end
 
-    OAUTH_CLIENT_OPTIONS = %w[username consumer_key consumer_secret token secret]
+    OAUTH_CLIENT_OPTIONS = %w[username consumer_key consumer_secret consumer_name token secret]
     attr_reader *OAUTH_CLIENT_OPTIONS
     attr_reader :username, :password
     def initialize(options = {})
@@ -57,6 +57,7 @@ module Twurl
       @password        = options['password']
       @consumer_key    = options['consumer_key']
       @consumer_secret = options['consumer_secret']
+      @consumer_name   = options['consumer_name']
       @token           = options['token']
       @secret          = options['secret']
       configure_http!

--- a/test/account_information_controller_test.rb
+++ b/test/account_information_controller_test.rb
@@ -59,3 +59,25 @@ class Twurl::AccountInformationController::DispatchWithOneUsernameThatHasAuthori
     controller.dispatch
   end
 end
+
+
+class Twurl::AccountInformationController::DisplayNamesForConsumerApplications < MiniTest::Unit::TestCase
+  attr_reader :options, :client, :controller
+  def setup
+    Twurl::OAuthClient.rcfile(true)
+    @options               = Twurl::Options.test_exemplar
+    @options.consumer_name = "exemplar_application"
+    @client                = Twurl::OAuthClient.load_new_client_from_options(options)
+    mock(Twurl::OAuthClient.rcfile).save.times(1)
+    Twurl::OAuthClient.rcfile << client
+
+    @controller = Twurl::AccountInformationController.new(client, options)
+  end
+
+  def test_consumer_name_is_displayed_for_account_if_present
+    mock(Twurl::CLI).puts(client.username).times(1).ordered
+    mock(Twurl::CLI).puts("  #{client.consumer_key} - #{client.consumer_name} (default)").times(1).ordered
+
+    controller.dispatch
+  end
+end


### PR DESCRIPTION
When I look at the different consumers I've authorized using twurl, it's hard to tell which is which:

```
$ twurl accounts

greenberg
  8TM35KfwdyL4JZa3X8gGC (default)
  gkwkGnTLoX5f26vyTr9et
  EB9SWuaMGW3sb6xgNUSAH
```

This changes lets users associate a name with each consumer key. This name is displayed in the list of accounts:

```
$ bin/twurl accounts

greenberg
  8TM35KfwdyL4JZa3X8gGC - DebugApplication (default)
  gkwkGnTLoX5f26vyTr9et - ProductionApplication
  EB9SWuaMGW3sb6xgNUSAH - CoffeeShopsTweeter
```

A subsequent change could allow users to provide consumer names when changing the configuration via `twurl set default`.
