### PR TITLE
fix issue that corrupts .twurlrc file when setting default profile

### DIFF
--- a/lib/twurl/rcfile.rb
+++ b/lib/twurl/rcfile.rb
@@ -35,7 +35,7 @@ module Twurl
     end
 
     def save
-      File.open(self.class.file_path, File::RDWR|File::CREAT, 0600) do |rcfile|
+      File.open(self.class.file_path, File::RDWR|File::CREAT|File::TRUNC, 0600) do |rcfile|
         rcfile.write data.to_yaml
       end
     end


### PR DESCRIPTION
fix issue that corrupts .twurlrc file when setting default profile to profile name shorter that existing default.

i have samples of this if you would like to review.

i.e. changing default to jrptest from jaakkosf will result in an extra line and character in the .twurlrc file, therefore making it a corrupted YAML file.
