### PR TITLE
add twurl version to user agent header

### DIFF
--- a/lib/twurl/request_controller.rb
+++ b/lib/twurl/request_controller.rb
@@ -6,6 +6,7 @@ module Twurl
         raise Exception, "You need to authorize first."
       end
       options.path ||= OAuthClient.rcfile.alias_from_options(options)
+      options.headers["User-Agent"] ||= "twurl #{Version}"
       perform_request
     end
 


### PR DESCRIPTION
Thoughts on this? Adding the twurl version to the user-agent helps in troubleshooting with different versions of twurl installed.

Adds:
User-Agent: twurl 0.9.2 (OAuth gem v0.4.7)
