### PR TITLE
Updated Install file with rake commands provided by install_tasks

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,11 +5,16 @@
   sudo gem i twurl --source http://rubygems.org
 
 +---------------------+
+| Build from source   |
++---------------------+
+
+  rake build
+
++---------------------+
 | Install from source |
 +---------------------+
 
-  rake dist:gem
-  sudo gem i pkg/twurl*gem
+  rake install
 
 +--------------+
 | Dependencies |


### PR DESCRIPTION
The rake dist:gem command doesn't seem to work anymore. The install_tasks method in the Rakefile provides the build and install tasks, so I updated the Install doc with them.
