### PR TITLE
[fix] Allowing raw request body when Content-Type is already specified

### DIFF
--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -107,7 +107,9 @@ module Twurl
         multipart_body << "\r\n--#{boundary}--\r\n"
 
         request.body = multipart_body.join
-        request['Content-Type'] = "multipart/form-data, boundary=\"#{boundary}\""
+        request.content_type = "multipart/form-data, boundary=\"#{boundary}\""
+      elsif request.content_type && options.data
+        request.body = options.data.keys.first
       elsif options.data
         request.set_form_data(options.data)
       end

--- a/test/oauth_client_test.rb
+++ b/test/oauth_client_test.rb
@@ -135,9 +135,37 @@ end
 class Twurl::OAuthClient::PerformingRequestsFromOptionsTest < Twurl::OAuthClient::AbstractOAuthClientTest
   def test_request_is_made_using_request_method_and_path_and_data_in_options
     client = Twurl::OAuthClient.test_exemplar
-    mock(client.consumer.http).request(satisfy { |req|
-                                         req.is_a?(Net::HTTP::Get) && (req.path == options.path)
-                                       })
+
+    mock(client.consumer.http).request(
+      satisfy { |req| req.is_a?(Net::HTTP::Get) && (req.path == options.path) }
+    )
+
+    client.perform_request_from_options(options)
+  end
+
+  def test_content_type_is_not_overridden_if_set_and_data_in_options
+    client = Twurl::OAuthClient.test_exemplar
+
+    options.request_method = 'post'
+    options.data           = { '{ "foo": "bar" }' => nil }
+    options.headers        = { 'Content-Type' => 'application/json' }
+
+    mock(client.consumer.http).request(
+      satisfy { |req| req.is_a?(Net::HTTP::Post) && req.content_type == 'application/json' }
+    )
+
+    client.perform_request_from_options(options)
+  end
+
+  def test_content_type_is_set_to_form_encoded_if_not_set_and_data_in_options
+    client = Twurl::OAuthClient.test_exemplar
+
+    options.request_method = 'post'
+    options.data           = { '{ "foo": "bar" }' => nil }
+
+    mock(client.consumer.http).request(
+      satisfy { |req| req.is_a?(Net::HTTP::Post) && req.content_type == 'application/x-www-form-urlencoded' }
+    )
 
     client.perform_request_from_options(options)
   end


### PR DESCRIPTION
Currently, when you use the `-d` option twurl calls `request.set_form_data` which URL encodes the request body and overrides any previously set `Content-Type` value by forcibly setting it to `application/x-www-form-urlencoded`.

https://github.com/twitter/twurl/blob/master/lib/twurl/oauth_client.rb#L112

Example without Modification (Unexpected Behavior):
```bash
twurl -t -X POST -A "Content-Type: application/json" "/1.1/some/endpoint" -d '{ "foo": "bar" }'

opening connection to api.twitter.com:443...
opened
starting SSL for api.twitter.com:443...
SSL established
<- "POST /1.1/some/endpoint HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: OAuth gem v0.4.7\r\nAuthorization: OAuth oauth_consumer_key=\"OIDntXZULiYrCzSBq23BQ\", oauth_nonce=\"oYU432ViX4OSSBLyWvThQ7jvxor5j84kN2Xy75SHDw\", oauth_signature=\"8v%2B4YEeV8gItbM100oyzFV5NwoU%3D\", oauth_signature_method=\"HMAC-SHA1\", oauth_timestamp=\"1433577823\", oauth_token=\"15678855-Q9DtXWXni83LwkqPcUl3dBkhtr9VgHu02nLKueKMI\", oauth_version=\"1.0\"\r\nConnection: close\r\nHost: api.twitter.com\r\nContent-Length: 30\r\n\r\n"
<- "%7B+%22foo%22%3A+%22bar%22+%7D"
```

This behavior prevents users from ever being able to send a request with `Content-Type: application/json` and a JSON payload in the request body. 

The change I'm making here is simple, non-breaking and preserves the default behavior while allowing the expected behavior you'd see in curl for the scenario described. If the request has `Content-Type` set to any value, we set `request.body` to the raw value of `options.data` and leave the content header untouched.

Example with Modification (Expected Behavior):
```bash
twurl -t -X POST -A "Content-Type: application/json" "/1.1/some/endpoint" -d '{ "foo": "bar" }'

opening connection to api.twitter.com:443...
opened
starting SSL for api.twitter.com:443...
SSL established
<- "POST /1.1/some/endpoint HTTP/1.1\r\nContent-Type: application/json\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: OAuth gem v0.4.7\r\nAuthorization: OAuth oauth_body_hash=\"Tj2XHfH2CojbvcRl2SoNiHqmQgM%3D\", oauth_consumer_key=\"OIDntXZULiYrCzSBq23BQ\", oauth_nonce=\"Kq6NBzJqGI5afVJVEbvOxMG9VuqeLcctiaSsQkDX2Q\", oauth_signature=\"a%2BGF7v4ZdUH%2FYk0f0gsKoL3b%2BAo%3D\", oauth_signature_method=\"HMAC-SHA1\", oauth_timestamp=\"1433578200\", oauth_token=\"15678855-Q9DtXWXni83LwkqPcUl3dBkhtr9VgHu02nLKueKMI\", oauth_version=\"1.0\"\r\nConnection: close\r\nHost: api.twitter.com\r\nContent-Length: 16\r\n\r\n"
<- "{ \"foo\": \"bar\" }"
```