### PR TITLE
fix token secret cli parsing

### DIFF
--- a/lib/twurl/cli.rb
+++ b/lib/twurl/cli.rb
@@ -205,7 +205,7 @@ Supported Commands: #{SUPPORTED_COMMANDS.sort.join(', ')}
       end
 
       def token_secret
-        on('-S', '--token-secret', "Your token secret") do |secret|
+        on('-S', '--token-secret [secret]', "Your token secret") do |secret|
           options.token_secret = secret
         end
       end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -70,6 +70,11 @@ class Twurl::CLI::OptionParsingTest < Minitest::Test
       assert_equal 'the-key', options.consumer_key
     end
 
+    def test_extracting_the_token_secret
+      options = Twurl::CLI.parse_options([TEST_PATH, '-S', 'the-secret'])
+      assert_equal 'the-secret', options.token_secret
+    end
+
     def test_consumer_key_option_with_no_value_prompts_user_for_value
       mock(Twurl::CLI).prompt_for('Consumer key').times(1) { 'inputted-key'}
       options = Twurl::CLI.parse_options([TEST_PATH, '-c'])


### PR DESCRIPTION
Problem

twurl crashes with a confusing error like 

> 0.9.3/lib/twurl/oauth_client.rb:138:in `gets': No such file or directory @ token_secret

when you supply the -S parameter to twurl authorize ie.

> twurl authorize -c client -s client_secret -a token -S token_secret

because the -S parameter does not take an argument, even though the docs say it should

Solution

make -S take an argument (and test that we can parse the argument)

Result

it doesn't crash
