### PR TITLE
docs(README): use markdown

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,5 @@
-+-------+
-| Twurl |
-+-------+
+Twurl
+=====
 
 Twurl is like curl, but tailored specifically for the Twitter API.
 It knows how to grant an access token to a client application for
@@ -11,21 +10,25 @@ as defining aliases for common requests, as well as support for
 multiple access tokens to easily switch between different client
 applications and Twitter accounts.
 
-+------------------+
-| Installing Twurl |
-+------------------+
+
+Installing Twurl
+----------------
 
 Twurl can be installed using ruby gems:
 
-  % gem install twurl
+```
+gem install twurl
+```
 
-+-----------------+
-| Getting Started |
-+-----------------+
+
+Getting Started
+---------------
 
 If you haven't already, the first thing to do is apply for a developer account to access Twitter APIs: 
 
-  https://developer.twitter.com/en/apply-for-access
+```
+https://developer.twitter.com/en/apply-for-access
+```
   
 After you have that access you can create a Twitter app and generate a consumer key and secret.  
   
@@ -34,86 +37,105 @@ When you have your consumer key and its secret you authorize
 your Twitter account to make API requests with your consumer key
 and secret.
 
-  % twurl authorize --consumer-key key       \
-                    --consumer-secret secret
+```
+twurl authorize --consumer-key key       \
+                --consumer-secret secret
+```
 
 This will return an URL that you should open up in your browser.
 Authenticate to Twitter, and then enter the returned PIN back into
 the terminal.  Assuming all that works well, you will be authorized
 to make requests with the API. Twurl will tell you as much.
 
-+-----------------+
-| Making Requests |
-+-----------------+
+
+Making Requests
+---------------
 
 The simplest request just requires that you specify the path you
 want to request.
 
-  % twurl /1.1/statuses/home_timeline.json
+```
+twurl /1.1/statuses/home_timeline.json
+```
 
 Similar to curl, a GET request is performed by default.
 
 You can implicitly perform a POST request by passing the -d option,
 which specifies POST parameters.
 
-  % twurl -d 'status=Testing twurl' /1.1/statuses/update.json
+```
+twurl -d 'status=Testing twurl' /1.1/statuses/update.json
+```
 
 You can explicitly specify what request method to perform with
 the -X (or --request-method) option.
 
-  % twurl -X POST /1.1/statuses/destroy/1234567890.json
+```
+twurl -X POST /1.1/statuses/destroy/1234567890.json
+```
 
-+------------------+
-| Creating aliases |
-+------------------+
 
-  % twurl alias h /1.1/statuses/home_timeline.json
+Creating aliases
+----------------
+
+```
+twurl alias h /1.1/statuses/home_timeline.json
+```
 
 You can then use "h" in place of the full path.
 
-  % twurl h
+```
+twurl h
+```
 
 Paths that require additional options such as request parameters for example can
 be used with aliases the same as with full explicit paths, just as you might
 expect.
 
-  % twurl alias tweet /1.1/statuses/update.json
-  % twurl tweet -d "status=Aliases in twurl are convenient"
+```
+twurl alias tweet /1.1/statuses/update.json
+twurl tweet -d "status=Aliases in twurl are convenient"
+```
 
-+-------------------------------+
-| Changing your default profile |
-+-------------------------------+
+
+Changing your default profile
+-----------------------------
 
 The first time you authorize a client application to make requests on behalf of your account, twurl stores your access token information in its .twurlrc file. Subsequent requests will use this profile as the default profile. You can use the 'accounts' subcommand to see what client applications have been authorized for what user names:
 
-  % twurl accounts
+```
+twurl accounts
   noradio
     HQsAGcBm5MQT4n6j7qVJw
     hhC7Koy2zRsTZvQh1hVlSA (default)
   testiverse
     guT9RsJbNQgVe6AwoY9BA
+```
 
 Notice that one of those consumer keys is marked as the default. To change the default use the 'set' subcommand, passing then either just the username, if it's unambiguous, or the username and consumer key pair if it isn't unambiguous:
 
-  % twurl set default testiverse
-  % twurl accounts
+```
+twurl set default testiverse
+twurl accounts
   noradio
     HQsAGcBm5MQT4n6j7qVJw
     hhC7Koy2zRsTZvQh1hVlSA
   testiverse
     guT9RsJbNQgVe6AwoY9BA (default)
+```
 
-  % twurl set default noradio HQsAGcBm5MQT4n6j7qVJw
-  % twurl accounts
+```
+twurl set default noradio HQsAGcBm5MQT4n6j7qVJw
+twurl accounts
   noradio
     HQsAGcBm5MQT4n6j7qVJw (default)
     hhC7Koy2zRsTZvQh1hVlSA
   testiverse
     guT9RsJbNQgVe6AwoY9BA
+```
 
-+--------------+
-| Contributors |
-+--------------+
+Contributors
+------------
 
 Marcel Molina <marcel@twitter.com> / @noradio
 Erik Michaels-Ober / @sferik


### PR DESCRIPTION
Problem
-------

File is not being formatted beautifully like usual on GitHub.

Solution
--------

Use markdown. 


NOTE
----

In order to take effect, file has to be renamed to README.md as well. Can't do that via GitHub.