### PR TITLE
Feature Request: username selection command line option #10

### DIFF
--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -11,7 +11,9 @@ module Twurl
       def load_from_options(options)
         if rcfile.has_oauth_profile_for_username_with_consumer_key?(options.username, options.consumer_key)
           load_client_for_username_and_consumer_key(options.username, options.consumer_key)
-        elsif options.username || (options.command == 'authorize')
+        elsif options.username
+          load_client_for_username(options.username)
+        elsif (options.command == 'authorize')
           load_new_client_from_options(options)
         else
           load_default_client


### PR DESCRIPTION
Problem

As detailed in #10:
> The two step process to ensure the correct username is used (in a script for example):
> 
> twurl set default username
> twurl tweet -d status="why's that?"
> 
> Seems a bit awkward. Couldn't -u be used for this?

Solution

Update oauth_client.rb to handle-u flag for selecting username (as explained in #10)

Result

The following: 
```
$ twurl -u user_one /1.1/statuses/home_timeline.json
$ twurl -u user_two /1.1/statuses/home_timeline.json
```
should yield different results