### PR TITLE
Fix path to README for twurl tutorial command

### DIFF
--- a/lib/twurl/cli.rb
+++ b/lib/twurl/cli.rb
@@ -4,7 +4,7 @@ module Twurl
     DEFAULT_COMMAND        = 'request'
     PATH_PATTERN           = /^\/\w+/
     PROTOCOL_PATTERN       = /^\w+:\/\//
-    README                 = File.dirname(__FILE__) + '/../../README'
+    README                 = File.dirname(__FILE__) + '/../../README.md'
     @output              ||= STDOUT
     class NoPathFound < Exception
     end


### PR DESCRIPTION
Problem

README file renamed in commit https://github.com/twitter/twurl/commit/0e969c283ea60be2e330d7f0ee3df17518deff37 .

```
bundle exec twurl -T
bundler: failed to load command: twurl (/usr/lib/ruby/gems/2.5.0/bin/twurl)
Errno::ENOENT: No such file or directory @ rb_sysopen - ...twurl/lib/twurl/../../README
...
```

Solution

Update path in code to refer to `README.md`.