### PR TITLE
Restore parsed POST body data if Content-Type is set

### DIFF
--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -109,7 +109,14 @@ module Twurl
         request.body = multipart_body.join
         request.content_type = "multipart/form-data, boundary=\"#{boundary}\""
       elsif request.content_type && options.data
-        request.body = options.data.keys.first
+        if options.data.length == 1 && options.data.values.first == nil
+          request.body = options.data.keys.first
+        else
+          request.body = ''
+          options.data.each_with_index do |(key, value), i|
+            request.body << (i == 0 ? '' : '&') + key.to_s + (value == nil ? '' : '=' + value.to_s)
+          end
+        end
       elsif options.data
         request.set_form_data(options.data)
       end

--- a/test/oauth_client_test.rb
+++ b/test/oauth_client_test.rb
@@ -157,6 +157,19 @@ class Twurl::OAuthClient::PerformingRequestsFromOptionsTest < Twurl::OAuthClient
     client.perform_request_from_options(options)
   end
 
+  def test_post_body_data_is_not_parsed_if_content_type_is_set
+
+    options.request_method = 'post'
+    options.data           = { '{ "data": "do' => nil, 'not' => 'parse', 'me' => '!" }' }
+    options.headers        = { 'Content-Type' => 'application/json' }
+
+    mock(client.consumer.http).request(
+      satisfy { |req| req.is_a?(Net::HTTP::Post) && req.body == '{ "data": "do&not=parse&me=!" }' }
+    )
+
+    client.perform_request_from_options(options)
+  end
+
   def test_content_type_is_set_to_form_encoded_if_not_set_and_data_in_options
     client = Twurl::OAuthClient.test_exemplar
 


### PR DESCRIPTION
Problem

See: https://github.com/twitter/twurl/issues/77
I'm seeing multiple reports from users for that issue.

Solution

I don't think this gonna be a permanent fix for sure, but can be a hotfix until someone figures out a better solution. As I mentioned in #77 , probably it's difficult to just remove those parse logic for several reasons, so this change does restore parsed POST data (hash) to raw data (text) right before making a request only if a "Content-Type" header is set.
