### PR TITLE
Use IO.binread instead of IO.read

### DIFF
--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -97,10 +97,10 @@ module Twurl
           multipart_body << "\r\n"
 
           if options.upload['base64']
-            enc = Base64.encode64(File.read(filename))
+            enc = Base64.encode64(File.binread(filename))
             multipart_body << enc
           else
-            multipart_body << File.read(filename)
+            multipart_body << File.binread(filename)
           end
         }
 


### PR DESCRIPTION
## Problem

Looks like there are multiple problems related to this code.

- Fix for Windows
https://github.com/twitter/twurl/issues/89
https://github.com/twitter/twurl/issues/68
https://github.com/twitter/twurl/issues/58

- Fix for Ruby 2.6.0+(?)
https://github.com/twitter/twurl/issues/109

`IO.read` doesn't handle binary file well due to encoding.
https://techblog.leosoto.com/reading-binary-file-on-ruby/

And for #109 , I can reproduce the same error with Ruby 2.6.0 + latest Mac OS X version and confirmed this PR fix the issue.

## Solution

Use `IO.binread` instead. This was introduced since Ruby 1.9.2, so it should be okay as twurl only supports 1.9.3+ as far as I know.

## Things to consider

As this PR will force `binread` for all files, I'm not sure if we want to keep existing implementation and then create a new option for binary file (e.g., `--file-binary`, which is similar to what curl [offers](https://ec.haxx.se/http-post.html))