### PR TITLE
Fix PIN authorization

### DIFF
--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -135,7 +135,7 @@ module Twurl
     def perform_pin_authorize_workflow
       @request_token = consumer.get_request_token
       CLI.puts("Go to #{generate_authorize_url} and paste in the supplied PIN")
-      pin = gets
+      pin = STDIN.gets
       access_token = @request_token.get_access_token(:oauth_verifier => pin.chomp)
       {:oauth_token => access_token.token, :oauth_token_secret => access_token.secret}
     end

--- a/twurl.gemspec
+++ b/twurl.gemspec
@@ -10,12 +10,12 @@ Gem::Specification.new do |spec|
   spec.description = %q{Curl for the Twitter API}
   spec.email = ['marcel@twitter.com']
   spec.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  spec.extra_rdoc_files = %w(COPYING INSTALL README)
+  spec.extra_rdoc_files = %w(COPYING INSTALL README.md)
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.start_with?('test/') }
   spec.homepage = 'http://github.com/twitter/twurl'
   spec.licenses = ['MIT']
   spec.name = 'twurl'
-  spec.rdoc_options = ['--title', 'twurl -- OAuth-enabled curl for the Twitter API', '--main', 'README', '--line-numbers', '--inline-source']
+  spec.rdoc_options = ['--title', 'twurl -- OAuth-enabled curl for the Twitter API', '--main', 'README.md', '--line-numbers', '--inline-source']
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 1.9.3'
   spec.rubyforge_project = 'twurl'


### PR DESCRIPTION
### Problem
Links to this issue https://github.com/twitter/twurl/issues/95.

`twurl athorize` fails when it attempts to gets to perform pin authorization like so:
```bash
/Users/profile/.rvm/gems/ruby-2.3.2/gems/twurl-0.9.3/lib/twurl/oauth_client.rb:138:in `gets': No such file or directory @ rb_sysopen - cvKmdC4vvK98ZXsrBKXYwWYqs2tG5xybebJGct4P76Wix (Errno::ENOENT)
	from /Users/profile/.rvm/gems/ruby-2.3.2/gems/twurl-0.9.3/lib/twurl/oauth_client.rb:138:in `gets'
from /Users/profile/.rvm/gems/ruby-2.3.2/gems/twurl-0.9.3/lib/twurl/oauth_client.rb:138:in `perform_pin_authorize_workflow'
	from /Users/profile/.rvm/gems/ruby-2.3.2/gems/twurl-0.9.3/lib/twurl/oauth_client.rb:125:in `rescue in exchange_credentials_for_access_token'
from /Users/profile/.rvm/gems/ruby-2.3.2/gems/twurl-0.9.3/lib/twurl/oauth_client.rb:122:in `exchange_credentials_for_access_token'
	from /Users/profile/.rvm/gems/ruby-2.3.2/gems/twurl-0.9.3/lib/twurl/authorization_controller.rb:6:in `dispatch'
from /Users/profile/.rvm/gems/ruby-2.3.2/gems/twurl-0.9.3/lib/twurl/abstract_command_controller.rb:7:in `dispatch'
	from /Users/profile/.rvm/gems/ruby-2.3.2/gems/twurl-0.9.3/lib/twurl/cli.rb:38:in `dispatch'
from /Users/profile/.rvm/gems/ruby-2.3.2/gems/twurl-0.9.3/lib/twurl/cli.rb:21:in `run'
	from /Users/profile/.rvm/gems/ruby-2.3.2/gems/twurl-0.9.3/bin/twurl:4:in `<top (required)>'
from /Users/profile/.rvm/gems/ruby-2.3.2/bin/twurl:22:in `load'
	from /Users/profile/.rvm/gems/ruby-2.3.2/bin/twurl:22:in `<main>'
from /Users/profile/.rvm/gems/ruby-2.3.2/bin/ruby_executable_hooks:15:in `eval'
	from /Users/profile/.rvm/gems/ruby-2.3.2/bin/ruby_executable_hooks:15:in `<main>'
```

After some poking around and googling there was  an incorrect usage of `gets` in the function that handled the PIN prompt. There is also another similar, but correctly handled prompt in the codebase here:
https://github.com/raethlo/twurl/blob/7eb9a1364cbc9e8ee30a81cf36db384eb363e0af/lib/twurl/cli.rb#L128

### Solution

Using `STDIN.gets()` instead of [`Kernel.gets()`](https://ruby-doc.org/core-2.6/Kernel.html#method-i-gets) fixes the issue. 

Extra:
Needed to fix `rake build` to work because README.md was incorrectly referenced in gemspec.

### Result

The PIN auth prompt will work as expected. And as a side-product `rake build` was fixed as well.
