### PR TITLE
Use https instead of http in urls

### DIFF
--- a/twurl.gemspec
+++ b/twurl.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   spec.extra_rdoc_files = %w(COPYING INSTALL README)
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.start_with?('test/') }
-  spec.homepage = 'http://github.com/twitter/twurl'
+  spec.homepage = 'https://github.com/twitter/twurl'
   spec.licenses = ['MIT']
   spec.name = 'twurl'
   spec.rdoc_options = ['--title', 'twurl -- OAuth-enabled curl for the Twitter API', '--main', 'README', '--line-numbers', '--inline-source']


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.