### PR TITLE
[bug fix] Stop manual URI parsing/escaping and use CGI::parse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ matrix:
     - rvm: ruby-head
     - rvm: rbx-2
   include:
-    - rvm: 2.6.4
-    - rvm: 2.5.6
-    - rvm: 2.4.7
+    - rvm: 2.6.5
+    - rvm: 2.5.7
+    - rvm: 2.4.9
     - rvm: jruby-head
     - rvm: ruby-head
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
-bundler_args: --without development
+dist: xenial
 language: ruby
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - jruby-head
-  - rbx-2
-  - ruby-head
+
+before_install:
+  - bundle config without 'development'
+
+branches:
+  only:
+    - master
+
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
-  fast_finish: true
-sudo: false
+    - rvm: rbx-2
+  include:
+    - rvm: 2.6.4
+    - rvm: 2.5.6
+    - rvm: 2.4.7
+    - rvm: jruby-head
+    - rvm: ruby-head
+    - rvm: rbx-2

--- a/lib/twurl/cli.rb
+++ b/lib/twurl/cli.rb
@@ -44,6 +44,7 @@ module Twurl
         arguments = args.dup
 
         Twurl.options         = Options.new
+        Twurl.options.args    = arguments
         Twurl.options.trace   = false
         Twurl.options.data    = {}
         Twurl.options.headers = {}
@@ -228,9 +229,13 @@ Supported Commands: #{SUPPORTED_COMMANDS.sort.join(', ')}
 
       def data
         on('-d', '--data [data]', 'Sends the specified data in a POST request to the HTTP server.') do |data|
-          data.split('&').each do |pair|
-            key, value = pair.split('=', 2)
-            options.data[key] = value
+          if options.args.count { |item| /content-type: (.*)/i.match(item) } > 0
+            options.data[data] = nil
+          else
+            data.split('&').each do |pair|
+              key, value = pair.split('=', 2)
+              options.data[key] = value
+            end
           end
         end
       end

--- a/lib/twurl/cli.rb
+++ b/lib/twurl/cli.rb
@@ -159,11 +159,8 @@ Supported Commands: #{SUPPORTED_COMMANDS.sort.join(', ')}
         end
 
         def escape_params(params)
-          split_params = params.split("&").map do |param|
-            key, value = param.split('=', 2)
-            CGI::escape(key) + '=' + CGI::escape(value)
-          end
-          split_params.join("&")
+          split_params = URI::decode_www_form(params)
+          URI::encode_www_form(split_params)
         end
     end
 

--- a/lib/twurl/cli.rb
+++ b/lib/twurl/cli.rb
@@ -159,8 +159,9 @@ Supported Commands: #{SUPPORTED_COMMANDS.sort.join(', ')}
         end
 
         def escape_params(params)
-          split_params = URI::decode_www_form(params)
-          URI::encode_www_form(split_params)
+          CGI::parse(params).map do |key, value|
+            "#{CGI.escape key}=#{CGI.escape value.first}"
+          end.join("&")
         end
     end
 

--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -111,7 +111,14 @@ module Twurl
       elsif request.content_type && options.data
         request.body = options.data.keys.first
       elsif options.data
-        request.set_form_data(options.data)
+        request.content_type = "application/x-www-form-urlencoded"
+        if options.data.length == 1 && options.data.values.first == nil
+          request.body = options.data.keys.first
+        else
+          request.body = options.data.map do |key, value|
+            "#{key}=#{CGI.escape value}"
+          end.join("&")
+        end
       end
 
       request.oauth!(consumer.http, consumer, access_token)

--- a/twurl.gemspec
+++ b/twurl.gemspec
@@ -5,7 +5,6 @@ require 'twurl/version'
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'oauth', '~> 0.4'
-  spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors = ["Marcel Molina", "Erik Michaels-Ober"]
   spec.description = %q{Curl for the Twitter API}
   spec.email = ['marcel@twitter.com']
@@ -17,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.name = 'twurl'
   spec.rdoc_options = ['--title', 'twurl -- OAuth-enabled curl for the Twitter API', '--main', 'README', '--line-numbers', '--inline-source']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.4.0'
   spec.rubyforge_project = 'twurl'
   spec.summary = spec.description
   spec.version = Twurl::Version


### PR DESCRIPTION
## Problem

Sometimes, users need to pass URL strings that contain query strings as a parameter.
E.g., `website_url` parameter from the [POST accounts/:account_id/cards/website](https://developer.twitter.com/en/docs/ads/creatives/api-reference/website#post-accounts-account-id-cards-website) endpoint (Ads API).

In this case, they have to escape the URL strings in order to let the parser to parse parameters correctly:

raw: `https://developer.twitter.com/params?aaa=bbb&ccc=ddd`
parsed: `https%3A%2F%2Fdeveloper.twitter.com%2Fparams%3Faaa%3Dbbb%26ccc%3Dddd`

```
$ twurl -XPOST -H ads-api.twitter.com '/6/accounts/18ce54t1ol3/cards/website?media_key=3_1102477685765206016&name=WebsiteCardTest-buggy&website_title=WebsiteCardTest-buggy&website_url=https%3A%2F%2Fdeveloper.twitter.com%2Fparams%3Faaa%3Dbbb%26ccc%3Dddd' | jq
```

but the problem is, this code block is doing some extra job and hence the parsed parameter I included in the above twurl request gets "double-escaped".
https://github.com/twitter/twurl/blob/v0.9.3/lib/twurl/cli.rb#L161-L167

so the above twurl request will actually fail like this:
```sh
$ twurl -XPOST -H ads-api.twitter.com '/6/accounts/18ce54t1ol3/cards/website?media_key=3_1102477685765206016&name=WebsiteCardTest-buggy&website_title=WebsiteCardTest-buggy&website_url=https%3A%2F%2Fdeveloper.twitter.com%2Fparams%3Faaa%3Dbbb%26ccc%3Dddd' | jq
{
  "errors": [
    {
      "code": "INVALID_PARAMETER",
      "message": "Invalid URL encoded params",
      "parameter": "website_url"
    }
  ],
  "request": {
    "params": {
      "name": "WebsiteCardTest-buggy",
      "account_id": "18ce54t1ol3",
      "media_key": "3_1102477685765206016",
      "website_title": "WebsiteCardTest-buggy",
      "website_url": "https%3A%2F%2Fdeveloper.twitter.com%2Fparams%3Faaa%3Dbbb%26ccc%3Dddd"
    }
  }
}
```

## Solution

Just stop doing manual URI parsing and use the `CGI::parse` method instead.

Result

```sh
$ twurl -XPOST -H ads-api.twitter.com '/6/accounts/18ce54t1ol3/cards/website?media_key=3_1102477685765206016&name=WebsiteCardTest-buggy&website_title=WebsiteCardTest-buggy&website_url=https%3A%2F%2Fdeveloper.twitter.com%2Fparams%3Faaa%3Dbbb%26ccc%3Dddd' | jq
{
  "data": {
    "name": "WebsiteCardTest-buggy",
    "website_shortened_url": "https://t.co/Vji3Zyh076",
    "image_display_height": "800",
    "media_url": "https://pbs.twimg.com/media/D0zJnTDUcAA0snp.png",
    "website_display_url": "developer.twitter.com",
    "id": "84w31",
    "website_dest_url": "https://developer.twitter.com/params",
    "media_key": "3_1102477685765206016",
    "created_at": "2019-10-01T02:20:03Z",
    "image_display_width": "800",
    "website_title": "WebsiteCardTest-buggy",
    "card_uri": "card://1178857075960471554",
    "website_url": "https://developer.twitter.com/params?aaa=bbb&ccc=ddd",
    "updated_at": "2019-10-01T02:20:03Z",
    "deleted": false,
    "card_type": "WEBSITE"
  },
  "request": {
    "params": {
      "name": "WebsiteCardTest-buggy",
      "website_shortened_url": "https://t.co/Vji3Zyh076",
      "image_display_height": "800",
      "media_url": "https://pbs.twimg.com/media/D0zJnTDUcAA0snp.png",
      "website_display_url": "developer.twitter.com",
      "account_id": "18ce54t1ol3",
      "website_dest_url": "https://developer.twitter.com/params",
      "media_key": "3_1102477685765206016",
      "image_display_width": "800",
      "website_title": "WebsiteCardTest-buggy",
      "website_url": "https://developer.twitter.com/params?aaa=bbb&ccc=ddd",
      "card_type": "WEBSITE"
    }
  }
}
```

As you can see, with this patch, 
`"website_url": "https://developer.twitter.com/params?aaa=bbb&ccc=ddd",`
which is what I expect to see.

### Other bug fixes
This PR includes other bug fixes that will resolve the below issues:
https://github.com/twitter/twurl/issues/117
https://github.com/twitter/twurl/issues/77 (initial PR was: https://github.com/twitter/twurl/pull/108)