### PR TITLE
Add twurl version to user agent header

### DIFF
--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -124,7 +124,13 @@ module Twurl
       end
 
       request.oauth!(consumer.http, consumer, access_token)
+      request['user-agent'] = user_agent
       consumer.http.request(request, &block)
+    end
+
+    def user_agent
+      "twurl version: #{Version} " \
+      "platform: #{RUBY_ENGINE} #{RUBY_VERSION} (#{RUBY_PLATFORM})"
     end
 
     def exchange_credentials_for_access_token

--- a/test/oauth_client_test.rb
+++ b/test/oauth_client_test.rb
@@ -167,6 +167,20 @@ class Twurl::OAuthClient::PerformingRequestsFromOptionsTest < Twurl::OAuthClient
 
     client.perform_request_from_options(options)
   end
+
+  def test_user_agent_request_header_is_set
+    client = Twurl::OAuthClient.test_exemplar
+    expected_ua_string = "twurl version: #{Twurl::Version} platform: #{RUBY_ENGINE} #{RUBY_VERSION} (#{RUBY_PLATFORM})"
+
+    mock(client.consumer.http).request(
+      satisfy { |req|
+        req.is_a?(Net::HTTP::Get) &&
+        req['user-agent'] == expected_ua_string
+      }
+    )
+
+    client.perform_request_from_options(options)
+  end
 end
 
 class Twurl::OAuthClient::CredentialsForAccessTokenExchangeTest < Twurl::OAuthClient::AbstractOAuthClientTest


### PR DESCRIPTION
Historically, twurl always uses `User-Agent: (OAuth gem v0.x.x)` request header that comes from the [oauth](https://github.com/oauth-xx/oauth-ruby) gem. For a better usage tracking/analytics purpose, we should consider adding a client's twurl, Ruby, and platform versions.

Original PR was opened in https://github.com/twitter/twurl/pull/50 but since it's too old, I'm submitting a new PR for this. Also, with the original PR, it still remains `(OAuth gem v0.x.x)` strings because of the oauth gem adds it on-the-fly. So I'm modifying it right after the `request.oauth!()` call rather than adding it in the request controller.

Example:
`User-Agent: twurl version: 0.9.3 platform: ruby 2.6.1 (x86_64-darwin17)`