### PR TITLE
Add --timeout and --connection-timeout options

### DIFF
--- a/lib/twurl/cli.rb
+++ b/lib/twurl/cli.rb
@@ -89,6 +89,8 @@ Supported Commands: #{SUPPORTED_COMMANDS.sort.join(', ')}
             file
             filefield
             base64
+            timeout
+            connection_timeout
           end
         end
 
@@ -324,6 +326,18 @@ Supported Commands: #{SUPPORTED_COMMANDS.sort.join(', ')}
       def base64
         on('-b', '--base64', 'Encode the uploaded file as base64 (default: false)') do |base64|
           options.upload['base64'] = base64
+        end
+      end
+
+      def timeout
+        on('--timeout [sec]', Integer, 'Number of seconds to wait for the request to be read (default: 60)') do |timeout|
+          options.timeout = timeout
+        end
+      end
+
+      def connection_timeout
+        on('--connection-timeout [sec]', Integer, 'Number of seconds to wait for the connection to open (default: 60)') do |connection_timeout|
+          options.connection_timeout = connection_timeout
         end
       end
     end

--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -208,7 +208,8 @@ module Twurl
       consumer.http.set_debug_output(Twurl.options.debug_output_io) if Twurl.options.trace
       consumer.http.read_timeout = consumer.http.open_timeout = Twurl.options.timeout || 60
       consumer.http.open_timeout = Twurl.options.connection_timeout if Twurl.options.connection_timeout
-      consumer.http.max_retries  = 0  # default is 1
+      # Only override if Net::HTTP support max_retries (since Ruby >= 2.5)
+      consumer.http.max_retries = 0 if consumer.http.respond_to?(:max_retries=)
       if Twurl.options.ssl?
         consumer.http.use_ssl     = true
         consumer.http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -206,6 +206,9 @@ module Twurl
 
     def configure_http!
       consumer.http.set_debug_output(Twurl.options.debug_output_io) if Twurl.options.trace
+      consumer.http.read_timeout = consumer.http.open_timeout = Twurl.options.timeout || 60
+      consumer.http.open_timeout = Twurl.options.connection_timeout if Twurl.options.connection_timeout
+      consumer.http.max_retries  = 0  # default is 1
       if Twurl.options.ssl?
         consumer.http.use_ssl     = true
         consumer.http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/test/account_information_controller_test.rb
+++ b/test/account_information_controller_test.rb
@@ -22,6 +22,7 @@ class Twurl::AccountInformationController::DispatchWithOneAuthorizedAccountTest 
     @options    = Twurl::Options.test_exemplar
     @client     = Twurl::OAuthClient.load_new_client_from_options(options)
     mock(Twurl::OAuthClient.rcfile).save.times(1)
+    Twurl::OAuthClient.rcfile.profiles.clear
     Twurl::OAuthClient.rcfile << client
     @controller = Twurl::AccountInformationController.new(client, options)
   end
@@ -51,10 +52,14 @@ class Twurl::AccountInformationController::DispatchWithOneUsernameThatHasAuthori
     @controller = Twurl::AccountInformationController.new(other_client, other_client_options)
   end
 
+  def teardown
+    Twurl::OAuthClient.rcfile.profiles[default_client.username][other_client.consumer_key].clear
+  end
+
   def test_authorized_account_is_displayed_and_marked_as_the_default
-    mock(Twurl::CLI).puts(default_client.username).times(1)
-    mock(Twurl::CLI).puts("  #{default_client.consumer_key} (default)").times(1)
-    mock(Twurl::CLI).puts("  #{other_client.consumer_key}").times(1)
+    mock(Twurl::CLI).puts(default_client.username).times(1).ordered
+    mock(Twurl::CLI).puts("  #{default_client.consumer_key} (default)").times(1).ordered
+    mock(Twurl::CLI).puts("  #{other_client.consumer_key}").times(1).ordered
 
     controller.dispatch
   end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -239,4 +239,19 @@ class Twurl::CLI::OptionParsingTest < Minitest::Test
     end
   end
   include ProxyOptionTests
+
+  module TimeoutOptionTests
+    def test_not_specifying_timeout_sets_it_to_nil
+      options = Twurl::CLI.parse_options([TEST_PATH])
+      assert_nil options.timeout
+      assert_nil options.connection_timeout
+    end
+
+    def test_setting_timeout_updates_to_requested_value
+      options = Twurl::CLI.parse_options([TEST_PATH, '--timeout', '10', '--connection-timeout', '5'])
+      assert_equal 10, options.timeout
+      assert_equal 5, options.connection_timeout
+    end
+  end
+  include TimeoutOptionTests
 end


### PR DESCRIPTION
## Problem

https://github.com/twitter/twurl/issues/36

Twurl currently doesn't have a way to override the default timeout values of the Net::HTTP Class. The default values are:

- `read_timeout`: 60 (seconds) [document](https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout-attribute-method)
- `open_timeout`: 60 (seconds) [document](https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout-attribute-method)

## Solution

Introduce new options below:
- `--timeout [sec]`
- `--connection-timeout [sec]`

## Result

### Usage output
```sh
$ bundle exec twurl
Usage: twurl authorize --consumer-key key --consumer-secret secret
       twurl [options] /1.1/statuses/home_timeline.json

Supported Commands: accounts, alias, authorize, set

Getting started:
    -T, --tutorial                   Narrative overview of how to get started using Twurl

Authorization options:
    -u, --username [username]        Username of account to authorize (required)
    -p, --password [password]        Password of account to authorize (required)
    -c, --consumer-key [key]         Your consumer key (required)
    -s, --consumer-secret [secret]   Your consumer secret (required)
    -a, --access-token [token]       Your access token
    -S, --token-secret [secret]      Your token secret

Common options:
    -t, --[no-]trace                 Trace request/response traffic (default: --no-trace)
    -d, --data [data]                Sends the specified data in a POST request to the HTTP server.
    -r, --raw-data [data]            Sends the specified data as it is in a POST request to the HTTP server.
    -A, --header [header]            Adds the specified header to the request to the HTTP server.
    -H, --host [host]                Specify host to make requests to (default: api.twitter.com)
    -q, --quiet                      Suppress all output (default: output is printed to STDOUT)
    -U, --no-ssl                     Disable SSL (default: SSL is enabled)
    -X, --request-method [method]    Request method (default: GET)
    -P, --proxy [proxy]              Specify HTTP proxy to forward requests to (default: No proxy)
    -f, --file [path_to_file]        Specify the path to the file to upload
    -F, --file-field [field_name]    Specify the POST parameter name for the file upload data (default: media)
    -b, --base64                     Encode the uploaded file as base64 (default: false)
        --timeout [sec]              Number of seconds to wait for the request to be read (default: 60)
        --connection-timeout [sec]   Number of seconds to wait for the connection to open (default: 60)
    -h, --help                       Show this message
    -v, --version                    Show version
```

### Actual test (using https://httpbin.org/#/Dynamic_data/get_delay__delay_)

```sh
$ time bundle exec twurl --timeout 5 -H httpbin.org "/delay/10"
Traceback (most recent call last):
        22: from /home/hoge/.rvm/gems/ruby-2.6.5/bin/ruby_executable_hooks:24:in `<main>'
        21: from /home/hoge/.rvm/gems/ruby-2.6.5/bin/ruby_executable_hooks:24:in `eval'
        20: from /home/hoge/.rvm/gems/ruby-2.6.5/bin/twurl:23:in `<main>'
        19: from /home/hoge/.rvm/gems/ruby-2.6.5/bin/twurl:23:in `load'
        18: from /home/hoge/Develop/GitHub/twurl/bin/twurl:4:in `<top (required)>'
        17: from /home/hoge/Develop/GitHub/twurl/lib/twurl/cli.rb:21:in `run'
        16: from /home/hoge/Develop/GitHub/twurl/lib/twurl/cli.rb:38:in `dispatch'
        15: from /home/hoge/Develop/GitHub/twurl/lib/twurl/abstract_command_controller.rb:7:in `dispatch'
        14: from /home/hoge/Develop/GitHub/twurl/lib/twurl/request_controller.rb:9:in `dispatch'
        13: from /home/hoge/Develop/GitHub/twurl/lib/twurl/request_controller.rb:13:in `perform_request'
        12: from /home/hoge/Develop/GitHub/twurl/lib/twurl/oauth_client.rb:128:in `perform_request_from_options'
        11: from /home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/http.rb:1470:in `request'
        10: from /home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/http.rb:920:in `start'
         9: from /home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/http.rb:1472:in `block in request'
         8: from /home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/http.rb:1479:in `request'
         7: from /home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/http.rb:1506:in `transport_request'
         6: from /home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/http.rb:1506:in `catch'
         5: from /home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/http.rb:1509:in `block in transport_request'
         4: from /home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/http/response.rb:29:in `read_new'
         3: from /home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/http/response.rb:40:in `read_status_line'
         2: from /home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/protocol.rb:201:in `readline'
         1: from /home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/protocol.rb:191:in `readuntil'
/home/hoge/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/net/protocol.rb:217:in `rbuf_fill': Net::ReadTimeout with #<TCPSocket:(closed)> (Net::ReadTimeout)

real    0m6.279s
user    0m0.513s
sys     0m0.084s
```