### PR TITLE
Release v0.9.4

### DIFF
--- a/lib/twurl/request_controller.rb
+++ b/lib/twurl/request_controller.rb
@@ -1,6 +1,10 @@
 module Twurl
   class RequestController < AbstractCommandController
     NO_URI_MESSAGE = "No URI specified"
+    READ_TIMEOUT_MESSAGE = 'A timeout occurred (Net::ReadTimeout). ' \
+                           'Please try again or increase the value using --timeout option.'
+    OPEN_TIMEOUT_MESSAGE = 'A timeout occurred (Net::OpenTimeout). ' \
+                           'Please try again or increase the value using --connection-timeout option.'
     def dispatch
       if client.needs_to_authorize?
         raise Exception, "You need to authorize first."
@@ -15,6 +19,10 @@ module Twurl
       }
     rescue URI::InvalidURIError
       CLI.puts NO_URI_MESSAGE
+    rescue Net::ReadTimeout
+      CLI.puts READ_TIMEOUT_MESSAGE
+    rescue Net::OpenTimeout
+      CLI.puts OPEN_TIMEOUT_MESSAGE
     end
   end
 end

--- a/lib/twurl/version.rb
+++ b/lib/twurl/version.rb
@@ -2,7 +2,7 @@ module Twurl
   class Version
     MAJOR = 0 unless defined? Twurl::Version::MAJOR
     MINOR = 9 unless defined? Twurl::Version::MINOR
-    PATCH = 3 unless defined? Twurl::Version::PATCH
+    PATCH = 4 unless defined? Twurl::Version::PATCH
     PRE = nil unless defined? Twurl::Version::PRE # Time.now.to_i.to_s
 
     class << self

--- a/twurl.gemspec
+++ b/twurl.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.description = %q{Curl for the Twitter API}
   spec.email = ['marcel@twitter.com']
   spec.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  spec.extra_rdoc_files = %w(COPYING INSTALL README.md)
+  spec.extra_rdoc_files = %w(CODE_OF_CONDUCT.md INSTALL LICENSE README.md)
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.start_with?('test/') }
   spec.homepage = 'http://github.com/twitter/twurl'
   spec.licenses = ['MIT']


### PR DESCRIPTION
- bump version to => v0.9.4
- Adding timeout error handling
- Fix .gemspec (due to https://github.com/twitter/twurl/pull/127)

```sh
$ bundle exec twurl --timeout 5 -H httpbin.org "/delay/10"
A timeout occurred (Net::ReadTimeout). Please try again or increase the value using --timeout option.
```