### PR TITLE
Support authorization options on request

### DIFF
--- a/lib/twurl/oauth_client.rb
+++ b/lib/twurl/oauth_client.rb
@@ -15,9 +15,15 @@ module Twurl
           load_client_for_username(options.username)
         elsif options.command == 'authorize'
           load_new_client_from_options(options)
+        elsif options.command == 'request' && has_oauth_options?(options)
+          load_new_client_from_oauth_options(options)
         else
           load_default_client
         end
+      end
+
+      def has_oauth_options?(options)
+        (options.consumer_key && options.consumer_secret && options.access_token && options.token_secret) ? true : false
       end
 
       def load_client_for_username_and_consumer_key(username, consumer_key)
@@ -43,6 +49,14 @@ module Twurl
 
       def load_new_client_from_options(options)
         new(options.oauth_client_options.merge('password' => options.password))
+      end
+
+      def load_new_client_from_oauth_options(options)
+        new(options.oauth_client_options.merge(
+            'token' => options.access_token,
+            'secret' => options.token_secret
+          )
+        )
       end
 
       def load_default_client

--- a/test/oauth_client_test.rb
+++ b/test/oauth_client_test.rb
@@ -72,6 +72,18 @@ class Twurl::OAuthClient::ClientLoadingFromOptionsTest < Twurl::OAuthClient::Abs
 
     Twurl::OAuthClient.load_from_options(options)
   end
+
+  def test_if_all_oauth_options_are_supplied_then_client_is_loaded_from_options
+    options.username = nil
+    options.command = 'request'
+    options.access_token = 'test_access_token'
+    options.token_secret = 'test_token_secret'
+
+    mock(Twurl::OAuthClient).load_new_client_from_oauth_options(options).times(1)
+    mock(Twurl::OAuthClient).load_default_client.never
+
+    Twurl::OAuthClient.load_from_options(options)
+  end
 end
 
 class Twurl::OAuthClient::ClientLoadingForUsernameTest < Twurl::OAuthClient::AbstractOAuthClientTest
@@ -127,6 +139,21 @@ class Twurl::OAuthClient::NewClientLoadingFromOptionsTest < Twurl::OAuthClient::
 
   def test_oauth_options_are_passed_through
     assert_equal client.to_hash, new_client.to_hash
+  end
+end
+
+class Twurl::OAuthClient::NewClientLoadingFromOauthOptionsTest < Twurl::OAuthClient::AbstractOAuthClientTest
+  attr_reader :new_client
+  def setup
+    super
+    options.access_token = 'test_access_token'
+    options.token_secret = 'test_token_secret'
+    @new_client = Twurl::OAuthClient.load_new_client_from_oauth_options(options)
+  end
+
+  def test_attributes_are_updated
+    assert_equal options.access_token, new_client.token
+    assert_equal options.token_secret, new_client.secret
   end
 end
 


### PR DESCRIPTION
feature-request: https://github.com/twitter/twurl/issues/120

so users can make a request without ~/.twurlrc file if all options (-c, -s, -a, and -S) are provided.