### PR TITLE
Add VSCode remote container setting files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:latest
+
+WORKDIR /usr/src/app
+
+COPY . .
+RUN bundle install

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+    "name": "twurl dev container",
+    "dockerFile": "Dockerfile",
+    "context": "..",
+    "workspaceFolder": "/usr/src/app",
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+    "shutdownAction": "none",
+    "extensions": [
+		"rebornix.Ruby"
+	]
+}

--- a/twurl.gemspec
+++ b/twurl.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ['--title', 'twurl -- OAuth-enabled curl for the Twitter API', '--main', 'README.md', '--line-numbers', '--inline-source']
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.4.0'
-  spec.rubyforge_project = 'twurl'
   spec.summary = spec.description
   spec.version = Twurl::Version
 end

--- a/twurl.gemspec
+++ b/twurl.gemspec
@@ -7,10 +7,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'oauth', '~> 0.4'
   spec.authors = ["Marcel Molina", "Erik Michaels-Ober", "@TwitterDev team"]
   spec.description = %q{Curl for the Twitter API}
-  spec.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  spec.extra_rdoc_files = %w(CODE_OF_CONDUCT.md CONTRIBUTING.md INSTALL.md LICENSE README.md)
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.start_with?('test/') }
-  spec.homepage = 'http://github.com/twitter/twurl'
+  spec.bindir = 'bin'
+  spec.executables << 'twurl'
+  spec.extra_rdoc_files = Dir["*.md", "LICENSE"]
+  spec.files = Dir["*.md", "LICENSE", "twurl.gemspec", "bin/*", "lib/**/*"]
+  spec.homepage = 'http://github.com/twitter/twurl' 
   spec.licenses = ['MIT']
   spec.name = 'twurl'
   spec.rdoc_options = ['--title', 'twurl -- OAuth-enabled curl for the Twitter API', '--main', 'README.md', '--line-numbers', '--inline-source']


### PR DESCRIPTION
https://code.visualstudio.com/docs/remote/containers
What does this mean? so developers who installed VSCode + Docker can start twurl development instantly without setting up Ruby environment on their own machines.

Also, removing `rubyforge_project` options from `.gemspec` as it's deprecated.