### PR TITLE
Use https for GitHub link

### DIFF
--- a/twurl.gemspec
+++ b/twurl.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'twurl/version'
@@ -11,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'twurl'
   spec.extra_rdoc_files = Dir["*.md", "LICENSE"]
   spec.files = Dir["*.md", "LICENSE", "twurl.gemspec", "bin/*", "lib/**/*"]
-  spec.homepage = 'http://github.com/twitter/twurl' 
+  spec.homepage = 'https://github.com/twitter/twurl'
   spec.licenses = ['MIT']
   spec.name = 'twurl'
   spec.rdoc_options = ['--title', 'twurl -- OAuth-enabled curl for the Twitter API', '--main', 'README.md', '--line-numbers', '--inline-source']


### PR DESCRIPTION
## Problem

I just want to clean up gemspec. 😄 

## Solution

- Use https for GitHub link
- Remove a magic comment

## Result

This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/twurl or some tools or APIs that use the gem's metadata.
