### PR TITLE
Add Ruby 3.2 to the CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
           - 'ruby-head'
           - 'jruby-head'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Problem

Current CI doesn't run against the most recent Ruby (3.2)

Solution

Added Ruby 3.2 to the CI matrix

Result

Ruby 3.2 will be included in the CI runs going forward.  Everything still runs green.